### PR TITLE
Update apache-pinot.mdx

### DIFF
--- a/docs/data-integrations/apache-pinot.mdx
+++ b/docs/data-integrations/apache-pinot.mdx
@@ -18,6 +18,10 @@ The required arguments to establish a connection are as follows:
 * `controller_port` is the port that the Controller of the Apache Pinot cluster is running on.
 * `path` is the query path.
 
+<Tip>
+If you installed MindsDB locally via pip, you need to install all handler dependencies manually. To do so, go to the handler's folder (mindsdb/integrations/handlers/pinot_handler) and run this command: `pip install -r requirements.txt`.
+</Tip>
+
 ## Usage
 
 In order to make use of this handler and connect to the Pinot cluster in MindsDB, the following syntax can be used:
@@ -41,6 +45,3 @@ You can use this established connection to query your table as follows:
 SELECT *
 FROM pinot_datasource.example_tbl;
 ```
-<Tip>
-If you installed MindsDB locally via pip, you need to install all handler dependencies manually. To do so, go to the handler's folder (mindsdb/integrations/handlers/pinot_handler) and run this command: `pip install -r requirements.txt`.
-</Tip>


### PR DESCRIPTION
**Added below text at the end of implementation chapter**

<Tip>
If you installed MindsDB locally via pip, you need to install all handler dependencies manually. To do so, go to the handler's folder (mindsdb/integrations/handlers/pinot_handler) and run this command: `pip install -r requirements.txt`. </Tip>

## Description
Added text at the end of implementation chapter

Please include a summary of the change and the issue it solves. 
Added text at the end of implementation chapter

**Fixes** #(issue)

## Type of change
- [x] 📄 This change requires a documentation update

### What is the solution?
Added text at the end of implementation chapter
<Tip>
If you installed MindsDB locally via pip, you need to install all handler dependencies manually. To do so, go to the handler's folder (mindsdb/integrations/handlers/pinot_handler) and run this command: `pip install -r requirements.txt`. </Tip>
## Checklist:
- [x] I have updated the documentation, or created issues to update them.
